### PR TITLE
Support HTML Cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     // This dependency is found on compile classpath of this component and consumers.
     implementation 'com.google.guava:guava:27.0.1-jre'
 
-    //compile files('src/main/java/dependencies/commons-codec-1.7.jar')
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Store a copy of the URL's HTML content on disk, so that:

* subsequent requests will be faster,
* the results can be deterministically reproduced, independent of subsequent changes to the web page,
* web traffic with Pinterest's bot will be reduced.

The code for the HTML cache is in its own new HTMLCache class, and calls are made from App.java