### PR TITLE
HTML Cache bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     // This dependency is found on compile classpath of this component and consumers.
     implementation 'com.google.guava:guava:27.0.1-jre'
 
-    //compile files('src/main/java/dependencies/commons-codec-1.7.jar')
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
For long URLs, the Base32 encoding scheme failed, because of the Linux length limit of 255 characters for file names. Fix: Use SHA 256 hashing instead.